### PR TITLE
Remove XSS vulnerability on the main page

### DIFF
--- a/js/roomElement.js
+++ b/js/roomElement.js
@@ -18,6 +18,8 @@
   };
 
   RoomElement.prototype.render = function () {
+    // HTML escape the subject before it is posted to the main page
+    this.options.subject = $('<div/>').text(this.options.subject).html();
     this.$el.html(this.template(this.options));
 
     this.$el.find('.tooltip-top').tooltipster({


### PR DESCRIPTION
Before there was no protection stopping users from submitting their own HTML including JavaScript functions. This could allow attackers to steal sensitive information like session cookies, or just to deface the page by changing page-wide CSS rules.
